### PR TITLE
Revert excessive posix join in `getPath()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const getExtensions = extensions => extensions.length > 1 ? `{${extensions.join(
 
 const getPath = (filepath, cwd) => {
 	const pth = filepath[0] === '!' ? filepath.slice(1) : filepath;
-	return path.isAbsolute(pth) ? pth : path.posix.join(cwd, pth);
+	return path.isAbsolute(pth) ? pth : path.join(cwd, pth);
 };
 
 const addExtensions = (file, extensions) => {


### PR DESCRIPTION
`getPath()` have to return a correct path of current OS to check directory existence.

cf. https://github.com/kevva/dir-glob/pull/18#discussion_r298801534, https://github.com/sindresorhus/globby/pull/126#issuecomment-506483745